### PR TITLE
Support LIBSDL2_TTF_SHLIB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Pending
+
+* Allow exact location of `libSDL2_ttf-2.0.so.0` to be set in
+  `LIBSDL2_TTF_SHLIB` for situations where you have a debug shared
+  library or you don't want `pkg-config` invoked.
+
 # 0.6 2023/08/05 hide startup log
 
 * Use system category to log "Loading Sdl_ttf" message. (We now

--- a/src/tsdl_ttf.ml
+++ b/src/tsdl_ttf.ml
@@ -65,7 +65,7 @@ module Ttf = struct
      #require "tsdl-ttf"
      in the toplevel, see
      https://github.com/ocamllabs/ocaml-ctypes/issues/70 *)
-  let from : Dl.library option =
+  let from_with_search : Dl.library option =
     (if debug then
        Sdl.(
          log_info Log.category_system "Loading Sdl_ttf, Target = %s"
@@ -115,6 +115,11 @@ module Ttf = struct
             print_endline
               ("Cannot find " ^ filename ^ ", please set LIBSDL2_PATH");
             None)
+
+  let from : Dl.library option =
+    let shlib = try Sys.getenv "LIBSDL2_TTF_SHLIB" with Not_found -> "" in
+    if shlib = "" then from_with_search
+    else Some Dl.(dlopen ~filename:shlib ~flags:[ RTLD_NOW ])
 
   let foreign = foreign ?from
   let init = foreign "TTF_Init" (void @-> returning zero_to_ok)


### PR DESCRIPTION
The environment variable avoids the runtime search for the SDL2_ttf shared library and also the Unix-specific fallback to pkg-config.

It allows a debug library (ex. SDL2_ttfd.dll) to be used.