### PR TITLE
Fix DLL lookup for current OPAM+MingW64 installations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # current
 
 * add `Ttf.glyph_is_provided32`, see https://wiki.libsdl.org/SDL2_ttf/TTF_GlyphIsProvided32
+* Fix DLL lookup for current OPAM+MingW64 installations
 
 # 0.6 2023/08/05 hide startup log
 

--- a/src/tsdl_ttf.ml
+++ b/src/tsdl_ttf.ml
@@ -77,7 +77,7 @@ module Ttf = struct
       | "win32" | "win64" ->
           (* On native Windows DLLs are loaded from the PATH *)
           ("SDL2_ttf.dll", [ "" ])
-      | "cygwin" | "mingw" ->
+      | "cygwin" | "mingw" | "mingw64" ->
           (* For Windows POSIX emulators (Cygwin and MSYS2), hardcoded
              locations are available in addition to the PATH *)
           ( "SDL2_ttf.dll",


### PR DESCRIPTION
On a current default install of OPAM on Windows, you get an OCaml installation with its `"system"` config flag set to `"mingw64"`.
The current code looks for `"mingw"` (not `"mingw64"`) and thus the code goes to the fallback case and tries (and fails) to load a `.so` file.

It's a bit difficult to test as it's currently non trivial no get a working `tsdl` on such a setup, but I swear, it works on my machine 🤡.
Also, it keeps the `"mingw"` case, so it shouldn't break any existing setup.