### PR TITLE
Use build-time linker to find preferred path to the SDL shared library.

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -18,4 +18,5 @@
   (tsdl (>= 0.9.1))
    conf-sdl2-ttf
   (ctypes (>= 0.4.0))
-   ctypes-foreign))
+   ctypes-foreign
+   dune-configurator))

--- a/src/config/discover.ml
+++ b/src/config/discover.ml
@@ -29,6 +29,17 @@ static const char *find_sdl2_ttf_path(void)
         return info.dli_fname;
     return NULL;
 }
+#elif defined(_WIN32)
+#include <windows.h>
+
+static const char *find_sdl2_ttf_path(void)
+{
+    static char path[MAX_PATH];
+    HMODULE h = GetModuleHandle("SDL2_ttf.dll");
+    if (h && GetModuleFileName(h, path, MAX_PATH))
+        return path;
+    return NULL;
+}
 #else
 static const char *find_sdl2_ttf_path(void) { return NULL; }
 #endif
@@ -49,6 +60,11 @@ int main(void)
 let none_module () =
   print_string "let library_path = None\nlet version = None\n"
 
+(* Note: this uses GCC-style compiler invocation (-o, -l flags) and sh-style
+   shell redirection (2>/dev/null). This works with GCC, Clang, and MinGW on
+   Windows, but not with MSVC (cl.exe), which uses different flag syntax
+   (/Fe: for output, .lib suffixes for libraries) and cmd.exe redirection.
+   MSVC is not supported here; the probe will fail gracefully and return None. *)
 let compile_and_run c conf =
   let cc = Option.value ~default:"cc" (C.ocaml_config_var c "c_compiler") in
   let extra_link_flags =
@@ -56,8 +72,10 @@ let compile_and_run c conf =
     | Some "macosx" -> []
     | _ -> [ "-ldl" ]
   in
+  let is_windows = Sys.os_type = "Win32" in
+  let devnull = if is_windows then "nul" else "/dev/null" in
   let c_file = Filename.temp_file "discover" ".c" in
-  let exe_file = Filename.temp_file "discover" "" in
+  let exe_file = Filename.temp_file "discover" (if is_windows then ".exe" else "") in
   let out_file = Filename.temp_file "discover_out" ".txt" in
   let cleanup () =
     List.iter (fun f -> try Sys.remove f with _ -> ()) [ c_file; exe_file; out_file ]
@@ -66,13 +84,14 @@ let compile_and_run c conf =
   output_string oc c_source;
   close_out oc;
   let compile_cmd =
-    Printf.sprintf "%s %s %s -o %s %s %s 2>/dev/null" cc
+    Printf.sprintf "%s %s %s -o %s %s %s 2>%s" cc
       (String.concat " " conf.C.Pkg_config.cflags)
       c_file exe_file
       (String.concat " " conf.C.Pkg_config.libs)
       (String.concat " " extra_link_flags)
+      devnull
   in
-  let run_cmd = Printf.sprintf "%s > %s 2>/dev/null" exe_file out_file in
+  let run_cmd = Printf.sprintf "%s > %s 2>%s" exe_file out_file devnull in
   let success =
     Sys.command compile_cmd = 0 && Sys.command run_cmd = 0
   in

--- a/src/config/discover.ml
+++ b/src/config/discover.ml
@@ -1,0 +1,100 @@
+module C = Configurator.V1
+
+let c_source =
+  {|
+#include <stdio.h>
+#include <SDL2/SDL_ttf.h>
+
+#ifdef __APPLE__
+#include <mach-o/dyld.h>
+#include <string.h>
+
+static const char *find_sdl2_ttf_path(void)
+{
+    uint32_t count = _dyld_image_count();
+    for (uint32_t i = 0; i < count; i++) {
+        const char *name = _dyld_get_image_name(i);
+        if (name && strstr(name, "SDL2_ttf"))
+            return name;
+    }
+    return NULL;
+}
+#elif defined(__unix__)
+#include <dlfcn.h>
+
+static const char *find_sdl2_ttf_path(void)
+{
+    Dl_info info;
+    if (dladdr((void *)TTF_Init, &info) && info.dli_fname)
+        return info.dli_fname;
+    return NULL;
+}
+#else
+static const char *find_sdl2_ttf_path(void) { return NULL; }
+#endif
+
+int main(void)
+{
+    const char *path = find_sdl2_ttf_path();
+    if (path)
+        printf("let library_path = Some \"%s\"\n", path);
+    else
+        printf("let library_path = None\n");
+    printf("let version = Some (%d, %d, %d)\n",
+           SDL_TTF_MAJOR_VERSION, SDL_TTF_MINOR_VERSION, SDL_TTF_PATCHLEVEL);
+    return 0;
+}
+|}
+
+let none_module () =
+  print_string "let library_path = None\nlet version = None\n"
+
+let compile_and_run c conf =
+  let cc = Option.value ~default:"cc" (C.ocaml_config_var c "c_compiler") in
+  let extra_link_flags =
+    match C.ocaml_config_var c "system" with
+    | Some "macosx" -> []
+    | _ -> [ "-ldl" ]
+  in
+  let c_file = Filename.temp_file "discover" ".c" in
+  let exe_file = Filename.temp_file "discover" "" in
+  let out_file = Filename.temp_file "discover_out" ".txt" in
+  let cleanup () =
+    List.iter (fun f -> try Sys.remove f with _ -> ()) [ c_file; exe_file; out_file ]
+  in
+  let oc = open_out c_file in
+  output_string oc c_source;
+  close_out oc;
+  let compile_cmd =
+    Printf.sprintf "%s %s %s -o %s %s %s 2>/dev/null" cc
+      (String.concat " " conf.C.Pkg_config.cflags)
+      c_file exe_file
+      (String.concat " " conf.C.Pkg_config.libs)
+      (String.concat " " extra_link_flags)
+  in
+  let run_cmd = Printf.sprintf "%s > %s 2>/dev/null" exe_file out_file in
+  let success =
+    Sys.command compile_cmd = 0 && Sys.command run_cmd = 0
+  in
+  if success then begin
+    let ic = open_in out_file in
+    (try while true do print_char (input_char ic) done with End_of_file -> ());
+    close_in ic
+  end;
+  cleanup ();
+  success
+
+let () =
+  C.main ~name:"sdl2-ttf-discover" (fun c ->
+      let default : C.Pkg_config.package_conf =
+        { libs = [ "-lSDL2_ttf" ]; cflags = [] }
+      in
+      let conf =
+        match C.Pkg_config.get c with
+        | None -> default
+        | Some pc -> (
+            match C.Pkg_config.query pc ~package:"SDL2_ttf" with
+            | None -> default
+            | Some deps -> deps)
+      in
+      if not (compile_and_run c conf) then none_module ())

--- a/src/config/discover.ml
+++ b/src/config/discover.ml
@@ -2,6 +2,7 @@ module C = Configurator.V1
 
 let c_source =
   {|
+#define _GNU_SOURCE
 #include <stdio.h>
 #include <SDL2/SDL_ttf.h>
 
@@ -20,14 +21,23 @@ static const char *find_sdl2_ttf_path(void)
     return NULL;
 }
 #elif defined(__unix__)
-#include <dlfcn.h>
+#include <link.h>
+#include <string.h>
+
+static int find_sdl2_ttf_cb(struct dl_phdr_info *info, size_t size, void *data)
+{
+    if (strstr(info->dlpi_name, "SDL2_ttf")) {
+        *(const char **)data = info->dlpi_name;
+        return 1;
+    }
+    return 0;
+}
 
 static const char *find_sdl2_ttf_path(void)
 {
-    Dl_info info;
-    if (dladdr((void *)TTF_Init, &info) && info.dli_fname)
-        return info.dli_fname;
-    return NULL;
+    const char *path = NULL;
+    dl_iterate_phdr(find_sdl2_ttf_cb, &path);
+    return path;
 }
 #elif defined(_WIN32)
 #include <windows.h>
@@ -46,13 +56,13 @@ static const char *find_sdl2_ttf_path(void) { return NULL; }
 
 int main(void)
 {
+    const SDL_version *v = TTF_Linked_Version();
     const char *path = find_sdl2_ttf_path();
     if (path)
         printf("let library_path = Some \"%s\"\n", path);
     else
         printf("let library_path = None\n");
-    printf("let version = Some (%d, %d, %d)\n",
-           SDL_TTF_MAJOR_VERSION, SDL_TTF_MINOR_VERSION, SDL_TTF_PATCHLEVEL);
+    printf("let version = Some (%d, %d, %d)\n", v->major, v->minor, v->patch);
     return 0;
 }
 |}
@@ -67,11 +77,6 @@ let none_module () =
    MSVC is not supported here; the probe will fail gracefully and return None. *)
 let compile_and_run c conf =
   let cc = Option.value ~default:"cc" (C.ocaml_config_var c "c_compiler") in
-  let extra_link_flags =
-    match C.ocaml_config_var c "system" with
-    | Some "macosx" -> []
-    | _ -> [ "-ldl" ]
-  in
   let is_windows = Sys.os_type = "Win32" in
   let devnull = if is_windows then "nul" else "/dev/null" in
   let c_file = Filename.temp_file "discover" ".c" in
@@ -88,23 +93,26 @@ let compile_and_run c conf =
   output_string oc c_source;
   close_out oc;
   let compile_cmd =
-    Printf.sprintf "%s %s %s -o %s %s %s 2>%s" cc
+    Printf.sprintf "%s %s %s -o %s %s 2>%s" cc
       (String.concat " " conf.C.Pkg_config.cflags)
       c_file exe_file
       (String.concat " " conf.C.Pkg_config.libs)
-      (String.concat " " extra_link_flags)
       devnull
   in
-  let run_cmd = Printf.sprintf "%s > %s 2>%s" exe_file out_file devnull in
-  let success = Sys.command compile_cmd = 0 && Sys.command run_cmd = 0 in
+  let run_cmd = Printf.sprintf "%s > %s" exe_file out_file in
+  let compile_ok = Sys.command compile_cmd = 0 in
+  if not compile_ok then
+    prerr_endline ("sdl2-ttf-discover: probe compilation failed: " ^ compile_cmd);
+  let run_ok = compile_ok && Sys.command run_cmd = 0 in
+  if compile_ok && not run_ok then
+    prerr_endline ("sdl2-ttf-discover: probe execution failed: " ^ run_cmd);
+  let success = compile_ok && run_ok in
   if success then begin
     let ic = open_in out_file in
-    (try
-       while true do
-         print_char (input_char ic)
-       done
-     with End_of_file -> ());
-    close_in ic
+    let output = In_channel.input_all ic in
+    close_in ic;
+    print_string output;
+    prerr_endline ("sdl2-ttf-discover: " ^ String.trim output)
   end;
   cleanup ();
   success
@@ -122,4 +130,9 @@ let () =
             | None -> default
             | Some deps -> deps)
       in
-      if not (compile_and_run c conf) then none_module ())
+      if not (compile_and_run c conf) then begin
+        prerr_endline
+          "sdl2-ttf-discover: could not detect SDL2_ttf library path, \
+           falling back to runtime heuristics";
+        none_module ()
+      end)

--- a/src/config/discover.ml
+++ b/src/config/discover.ml
@@ -75,10 +75,14 @@ let compile_and_run c conf =
   let is_windows = Sys.os_type = "Win32" in
   let devnull = if is_windows then "nul" else "/dev/null" in
   let c_file = Filename.temp_file "discover" ".c" in
-  let exe_file = Filename.temp_file "discover" (if is_windows then ".exe" else "") in
+  let exe_file =
+    Filename.temp_file "discover" (if is_windows then ".exe" else "")
+  in
   let out_file = Filename.temp_file "discover_out" ".txt" in
   let cleanup () =
-    List.iter (fun f -> try Sys.remove f with _ -> ()) [ c_file; exe_file; out_file ]
+    List.iter
+      (fun f -> try Sys.remove f with _ -> ())
+      [ c_file; exe_file; out_file ]
   in
   let oc = open_out c_file in
   output_string oc c_source;
@@ -92,12 +96,14 @@ let compile_and_run c conf =
       devnull
   in
   let run_cmd = Printf.sprintf "%s > %s 2>%s" exe_file out_file devnull in
-  let success =
-    Sys.command compile_cmd = 0 && Sys.command run_cmd = 0
-  in
+  let success = Sys.command compile_cmd = 0 && Sys.command run_cmd = 0 in
   if success then begin
     let ic = open_in out_file in
-    (try while true do print_char (input_char ic) done with End_of_file -> ());
+    (try
+       while true do
+         print_char (input_char ic)
+       done
+     with End_of_file -> ());
     close_in ic
   end;
   cleanup ();

--- a/src/config/dune
+++ b/src/config/dune
@@ -1,0 +1,3 @@
+(executable
+ (name discover)
+ (libraries dune-configurator))

--- a/src/dune
+++ b/src/dune
@@ -2,3 +2,10 @@
  (name tsdl_ttf)
  (public_name tsdl-ttf)
  (libraries tsdl))
+
+(rule
+ (targets sdl2_ttf_config.ml)
+ (action
+  (with-stdout-to
+   %{targets}
+   (run ./config/discover.exe))))

--- a/src/tsdl_ttf.ml
+++ b/src/tsdl_ttf.ml
@@ -70,26 +70,29 @@ module Ttf = struct
   *)
 
   let sdl2_ttf_candidates =
-    match Sys.os_type with
-    | "Win32" | "Cygwin" -> [ "SDL2_ttf.dll" ]
-    | "Unix" ->
-        [
-          (* Linux *)
-          "libSDL2_ttf.so";
-          "libSDL2_ttf-2.0.so.0";
-          (* FreeBSD (Not necessary?) *)
-          "libSDL2_ttf.so.0";
-          "/usr/local/lib/libSDL2_ttf.so";
-          "/usr/local/lib/libSDL2_ttf.so.0";
-          "/usr/lib/x86_64-linux-gnu/libSDL2_ttf-2.0.so.0";
-          (* MacOS *)
-          "libSDL2_ttf.dylib";
-          "/Library/Frameworks/SDL2_ttf.framework/SDL2_ttf";
-          "/usr/local/lib/libSDL2_ttf.dylib";
-          "/opt/homebrew/lib/libSDL2_ttf.dylib";
-          "/opt/local/lib/libSDL2_ttf.dylib";
-        ]
-    | _ -> []
+    let platform_candidates =
+      match Sys.os_type with
+      | "Win32" | "Cygwin" -> [ "SDL2_ttf.dll" ]
+      | "Unix" ->
+          [
+            (* Linux *)
+            "libSDL2_ttf.so";
+            "libSDL2_ttf-2.0.so.0";
+            (* FreeBSD (Not necessary?) *)
+            "libSDL2_ttf.so.0";
+            "/usr/local/lib/libSDL2_ttf.so";
+            "/usr/local/lib/libSDL2_ttf.so.0";
+            "/usr/lib/x86_64-linux-gnu/libSDL2_ttf-2.0.so.0";
+            (* MacOS *)
+            "libSDL2_ttf.dylib";
+            "/Library/Frameworks/SDL2_ttf.framework/SDL2_ttf";
+            "/usr/local/lib/libSDL2_ttf.dylib";
+            "/opt/homebrew/lib/libSDL2_ttf.dylib";
+            "/opt/local/lib/libSDL2_ttf.dylib";
+          ]
+      | _ -> []
+    in
+    Option.to_list Sdl2_ttf_config.library_path @ platform_candidates
 
   let lib_sdl2 =
     Dynlib.load

--- a/src/tsdl_ttf.ml
+++ b/src/tsdl_ttf.ml
@@ -94,6 +94,12 @@ module Ttf = struct
     in
     Option.to_list Sdl2_ttf_config.library_path @ platform_candidates
 
+  let () =
+    if debug then
+      Option.iter
+        (fun s -> print_endline ("Library path detected at build time: " ^ s))
+        Sdl2_ttf_config.library_path
+
   let lib_sdl2 =
     Dynlib.load
       ~env:[ "SDL2_TTF_LIBRARY"; "LIBSDL2_TTF_SHLIB" ]

--- a/tsdl-ttf.opam
+++ b/tsdl-ttf.opam
@@ -17,6 +17,7 @@ depends: [
   "conf-sdl2-ttf"
   "ctypes" {>= "0.4.0"}
   "ctypes-foreign"
+  "dune-configurator"
   "odoc" {with-doc}
 ]
 build: [


### PR DESCRIPTION
This PR leverages `dune-configurator` and `pkg-config` to build a build-time C program printing the linked path to SDL shared object and use it at runtime over the runtime detection heuristics.

Using the linker to find the path to the `SDL` shared library that will be needed for the final program is the most robust approach. It covers situations where then program is built using the development environment provided by the system and then later distributed using the system's runtime packages.

These changes follow a regression reported in #14 and detected in https://github.com/savonet/liquidsoap/actions/runs/24903148448/job/72940913196. In this build, typically, the binary is built using `opam` which provides the development environment for building with `SDL`:

```shell
% opam show conf-sdl2-ttf                                                                                                                                   08:30:39
...
depends     "conf-pkg-config" {build}
            ("host-arch-x86_32" {os = "win32" & os-distribution != "cygwinports"} &
             "conf-mingw-w64-sdl2-ttf-i686"
               {os = "win32" & os-distribution != "cygwinports"} |
             "host-arch-x86_64" {os = "win32" & os-distribution != "cygwinports"} &
             "conf-mingw-w64-sdl2-ttf-x86_64"
               {os = "win32" & os-distribution != "cygwinports"})
depexts     ["sdl2_ttf-dev"] {os-family = "alpine"}
            ["libsdl2-ttf-dev"] {os-family = "debian"}
            ["libsdl2-ttf-dev"] {os-family = "ubuntu"}
            ["libsdl2_ttf-devel"] {os-family = "mageia"}
            ["SDL2_ttf-devel"] {os-family = "suse" | os-family = "opensuse"}
            ["SDL2_ttf-devel"] {os-family = "fedora"}
            ["epel-release" "SDL2_ttf-devel"] {os-distribution = "centos"}
            ["sdl2_ttf"] {os-family = "arch"}
            ["sdl2-ttf"] {os-family = "gentoo"}
            ["sdl2_ttf"] {os-distribution = "homebrew" & os = "macos"}
            ["sdl2_ttf"] {os = "freebsd"}
            ["sdl2-ttf"] {os = "openbsd"}
            ["SDL2_ttf"] {os = "netbsd"}
            ["SDL2_ttf"] {os = "nixos"}
            ["libSDL2_ttf-devel"] {os = "cygwin"}
...
```
Then, the package is created using only the runtime package containing the shared library without the development environment: https://github.com/savonet/liquidsoap/blob/main/.github/alpine/APKBUILD.in#L10
```
depends="sdl2 sdl2_image sdl2_ttf"
```

This workflow is quite natural and follows how binaries actually linking to the library at build time would work. In fact, I suspect, most users of this package will not care if it is using `dlopen` or a link-time shared link.

Additionally, tweaking build-time variables such as `PKG_CONFIG_PATH` and etc is the most common way to guide the build system to find the right path to the shared library. This is for instance used when cross-compiling.

To make the build here follow this pattern, the PR introduces a build-time C program that is linked against `SDL` and reports the link-time path to it. This value is then used to generate a build-time OCaml module.

The path discovery uses platform-specific APIs:
- **macOS**: `_dyld_get_image_name()` from `<mach-o/dyld.h>`, which returns the actual resolved path (unlike `dladdr`, which may return an `@rpath`-style install name)
- **Linux/Unix**: `dladdr(TTF_Init, ...)` from `<dlfcn.h>`, which asks the dynamic linker which loaded file the symbol came from
- **Windows**: `GetModuleHandle("SDL2_ttf.dll")` + `GetModuleFileName()` from `<windows.h>`, which looks up the already-loaded DLL and returns its full path. This works with GCC/Clang (MinGW). MSVC is not supported — the probe fails gracefully and returns `None`, falling back to runtime heuristics.

```c
#include <stdio.h>
#include <SDL2/SDL_ttf.h>

#ifdef __APPLE__
#include <mach-o/dyld.h>
#include <string.h>

static const char *find_sdl2_ttf_path(void)
{
    uint32_t count = _dyld_image_count();
    for (uint32_t i = 0; i < count; i++) {
        const char *name = _dyld_get_image_name(i);
        if (name && strstr(name, "SDL2_ttf"))
            return name;
    }
    return NULL;
}
#elif defined(__unix__)
#include <dlfcn.h>

static const char *find_sdl2_ttf_path(void)
{
    Dl_info info;
    if (dladdr((void *)TTF_Init, &info) && info.dli_fname)
        return info.dli_fname;
    return NULL;
}
#elif defined(_WIN32)
#include <windows.h>

static const char *find_sdl2_ttf_path(void)
{
    static char path[MAX_PATH];
    HMODULE h = GetModuleHandle("SDL2_ttf.dll");
    if (h && GetModuleFileName(h, path, MAX_PATH))
        return path;
    return NULL;
}
#else
static const char *find_sdl2_ttf_path(void) { return NULL; }
#endif

int main(void)
{
    const char *path = find_sdl2_ttf_path();
    if (path)
        printf("let library_path = Some \"%s\"\n", path);
    else
        printf("let library_path = None\n");
    printf("let version = Some (%d, %d, %d)\n",
           SDL_TTF_MAJOR_VERSION, SDL_TTF_MINOR_VERSION, SDL_TTF_PATCHLEVEL);
    return 0;
}
```


```dune
(rule
 (targets sdl2_ttf_config.ml)
 (action
  (with-stdout-to %{targets}
   (run ./config/discover.exe))))
```

At runtime, if the build-time module has a non-`None` value for the path to the shared `SDL` library, it is used over the runtime heuristics, ensuring that the library detected at build time takes precedent over other, more approximative guesses:

```ocaml
  let sdl2_ttf_candidates =
    let platform_candidates =
...
      | _ -> []
    in
    Option.to_list Sdl2_ttf_config.library_path @ platform_candidates
 ```
